### PR TITLE
Remove duplicate Replicate Database Roles sections from migration docs

### DIFF
--- a/docs/migrations/alloydb.mdx
+++ b/docs/migrations/alloydb.mdx
@@ -69,40 +69,6 @@ chmod +x alloydb-auth-proxy
 postgresql://your_username:your_password@your-alloydb-ip:5432/your_database?sslmode=require
 ```
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:

--- a/docs/migrations/aws-aurora.mdx
+++ b/docs/migrations/aws-aurora.mdx
@@ -56,40 +56,6 @@ postgresql://your_username:your_password@your-aurora-endpoint:5432/your_database
 
 You can find the endpoint in the AWS Aurora Console under your cluster details.
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:

--- a/docs/migrations/aws-rds.mdx
+++ b/docs/migrations/aws-rds.mdx
@@ -57,40 +57,6 @@ postgresql://your_username:your_password@your-rds-endpoint:5432/your_database
 
 You can find the endpoint in the AWS RDS Console under your instance details.
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:

--- a/docs/migrations/azure.mdx
+++ b/docs/migrations/azure.mdx
@@ -65,40 +65,6 @@ Azure connection strings typically look like this:
 postgresql://your_username:your_password@your-server.postgres.database.azure.com:5432/postgres?sslmode=require
 ```
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:

--- a/docs/migrations/digitalocean.mdx
+++ b/docs/migrations/digitalocean.mdx
@@ -64,40 +64,6 @@ DigitalOcean connection strings typically look like this:
 postgresql://your_username:your_password@your-db-host:5432/defaultdb?sslmode=require
 ```
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:

--- a/docs/migrations/gcp-cloudsql.mdx
+++ b/docs/migrations/gcp-cloudsql.mdx
@@ -67,40 +67,6 @@ chmod +x cloud-sql-proxy
 postgresql://your_username:your_password@your-cloudsql-ip:5432/your_database?sslmode=require
 ```
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:

--- a/docs/migrations/heroku.mdx
+++ b/docs/migrations/heroku.mdx
@@ -64,40 +64,6 @@ If you're on a Premium plan with private access:
 2. **Configure VPC peering** if needed
 3. **Run migration from within Heroku** environment
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:

--- a/docs/migrations/neon.mdx
+++ b/docs/migrations/neon.mdx
@@ -40,40 +40,6 @@ Neon connection strings typically look like this:
 postgresql://your_username:your_password@ep-cool-name-123456.us-east-2.aws.neon.tech/your_db?sslmode=require
 ```
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:

--- a/docs/migrations/self-hosted.mdx
+++ b/docs/migrations/self-hosted.mdx
@@ -84,40 +84,6 @@ If SSL is disabled:
 postgresql://your_username:your_password@your-server-ip:5432/your_database?sslmode=disable
 ```
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:

--- a/docs/migrations/supabase.mdx
+++ b/docs/migrations/supabase.mdx
@@ -48,40 +48,6 @@ Supabase requires SSL by default. Include SSL parameters in your connection stri
 postgresql://your_username:your_password@db.[YOUR-PROJECT-REF].supabase.co:5432/postgres
 ```
 
-## Replicate Database Roles
-
-Before migrating your data, you'll need to replicate the database roles from your source database to your Xata branch.
-
-### Extract Roles from Source Database
-
-Connect to your source database and extract the role definitions:
-
-```sql
--- Extract role definitions (run this on your source database)
-SELECT 
-    'CREATE ROLE ' || rolname || ' WITH ' ||
-    CASE WHEN rolcanlogin THEN 'LOGIN ' ELSE 'NOLOGIN ' END ||
-    CASE WHEN rolsuper THEN 'SUPERUSER ' ELSE 'NOSUPERUSER ' END ||
-    CASE WHEN rolinherit THEN 'INHERIT ' ELSE 'NOINHERIT ' END ||
-    CASE WHEN rolcreaterole THEN 'CREATEROLE ' ELSE 'NOCREATEROLE ' END ||
-    CASE WHEN rolcreatedb THEN 'CREATEDB ' ELSE 'NOCREATEDB ' END ||
-    CASE WHEN rolreplication THEN 'REPLICATION ' ELSE 'NOREPLICATION ' END ||
-    CASE WHEN rolbypassrls THEN 'BYPASSRLS ' ELSE 'NOBYPASSRLS ' END ||
-    'CONNECTION LIMIT ' || COALESCE(rolconnlimit, -1) || ';' as create_role_statement
-FROM pg_roles 
-WHERE rolname NOT LIKE 'pg_%'
-ORDER BY rolname;
-```
-
-### Apply Roles to Xata Branch
-
-1. **Connect to your Xata branch**:
-   ```bash
-   psql `xata branch url`
-   ```
-
-2. **Execute the role creation statements** from the previous step
-
 ## Initialize Xata Project
 
 Set up your Xata project configuration:


### PR DESCRIPTION
## Summary

No longer needed after https://github.com/xataio/frontend/pull/1365

- Removed duplicate "Replicate Database Roles" sections from all 10 migration documentation files
- Each file had one section that was removed completely, from the heading through "Execute the role creation statements from the previous step"
- Total of 340 lines removed across all files

## Changes
Affected files:
- docs/migrations/alloydb.mdx
- docs/migrations/aws-aurora.mdx
- docs/migrations/aws-rds.mdx
- docs/migrations/azure.mdx
- docs/migrations/digitalocean.mdx
- docs/migrations/gcp-cloudsql.mdx
- docs/migrations/heroku.mdx
- docs/migrations/neon.mdx
- docs/migrations/self-hosted.mdx
- docs/migrations/supabase.mdx

## Test plan
- [x] Verified all "Replicate Database Roles" sections were removed
- [x] Confirmed no remaining references to the removed content
- [x] Documentation builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)